### PR TITLE
ci: run AVA across Linux, Windows, and macOS

### DIFF
--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -6,4 +6,4 @@ Purpose: trigger the pull-request CI workflow for an isolated verification run.
 - No credentials or private data included.
 - No external-system actions.
 - Branch: `automation/run-all-workflows-20260718`
-- Synchronize event: `2026-08-16T15:04:00Z`
+- Synchronize event: `2026-08-17T21:45:07Z`

--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -6,4 +6,4 @@ Purpose: trigger the pull-request CI workflow for an isolated verification run.
 - No credentials or private data included.
 - No external-system actions.
 - Branch: `automation/run-all-workflows-20260718`
-- Synchronize event: `2026-07-18T18:36Z`
+- Synchronize event: `2026-08-16T14:53:19Z`

--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -6,4 +6,4 @@ Purpose: trigger the pull-request CI workflow for an isolated verification run.
 - No credentials or private data included.
 - No external-system actions.
 - Branch: `automation/run-all-workflows-20260718`
-- Synchronize event: `2026-08-23T10:02:20.094Z`
+- Synchronize event: `2026-08-24T01:04:08Z`

--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -6,4 +6,4 @@ Purpose: trigger the pull-request CI workflow for an isolated verification run.
 - No credentials or private data included.
 - No external-system actions.
 - Branch: `automation/run-all-workflows-20260718`
-- Synchronize event: `2026-08-17T21:45:07Z`
+- Synchronize event: `2026-08-18T09:20:23.682Z`

--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -6,4 +6,4 @@ Purpose: trigger the pull-request CI workflow for an isolated verification run.
 - No credentials or private data included.
 - No external-system actions.
 - Branch: `automation/run-all-workflows-20260718`
-- Synchronize event: `2026-08-22T20:15:07Z`
+- Synchronize event: `2026-08-23T10:02:20.094Z`

--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -6,3 +6,4 @@ Purpose: trigger the pull-request CI workflow for an isolated verification run.
 - No credentials or private data included.
 - No external-system actions.
 - Branch: `automation/run-all-workflows-20260718`
+- Synchronize event: `2026-07-18T18:36Z`

--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -6,4 +6,4 @@ Purpose: trigger the pull-request CI workflow for an isolated verification run.
 - No credentials or private data included.
 - No external-system actions.
 - Branch: `automation/run-all-workflows-20260718`
-- Synchronize event: `2026-08-16T14:53:19Z`
+- Synchronize event: `2026-08-16T15:04:00Z`

--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -6,4 +6,4 @@ Purpose: trigger the pull-request CI workflow for an isolated verification run.
 - No credentials or private data included.
 - No external-system actions.
 - Branch: `automation/run-all-workflows-20260718`
-- Synchronize event: `2026-08-20T13:28:22.975Z`
+- Synchronize event: `2026-08-21T20:22:07Z`

--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -6,4 +6,4 @@ Purpose: trigger the pull-request CI workflow for an isolated verification run.
 - No credentials or private data included.
 - No external-system actions.
 - Branch: `automation/run-all-workflows-20260718`
-- Synchronize event: `2026-08-18T09:20:23.682Z`
+- Synchronize event: `2026-08-20T13:28:22.975Z`

--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -6,4 +6,4 @@ Purpose: trigger the pull-request CI workflow for an isolated verification run.
 - No credentials or private data included.
 - No external-system actions.
 - Branch: `automation/run-all-workflows-20260718`
-- Synchronize event: `2026-08-21T20:22:07Z`
+- Synchronize event: `2026-08-22T20:15:07Z`

--- a/.github/workflow-triggers/run-all-20260718.md
+++ b/.github/workflow-triggers/run-all-20260718.md
@@ -1,0 +1,8 @@
+# AVA Workflow Trigger — 2026-07-18
+
+Purpose: trigger the pull-request CI workflow for an isolated verification run.
+
+- No runtime product behavior changed.
+- No credentials or private data included.
+- No external-system actions.
+- Branch: `automation/run-all-workflows-20260718`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,20 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [20, 22]
 
     steps:
       - uses: actions/checkout@v4
@@ -18,7 +26,13 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
 
       - name: Run tests
         run: npm test
+
+      - name: Start library
+        run: npm start
+
+      - name: Start CLI smoke test
+        run: node bin/cli.js --color

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const os = require('os');
 const {run, runAll, runAsync, runAllParallel} = require('../src/run');
 
 let passed = 0;
@@ -56,8 +57,9 @@ async function main() {
 	});
 
 	await test('should accept a cwd option', () => {
-		const result = run('node -e "console.log(process.cwd())"', {silent: true, cwd: '/tmp'});
-		assert.strictEqual(result.stdout.trim(), '/tmp');
+		const cwd = os.tmpdir();
+		const result = run('node -e "console.log(process.cwd())"', {silent: true, cwd});
+		assert.strictEqual(result.stdout.trim(), cwd);
 		assert.strictEqual(result.exitCode, 0);
 	});
 
@@ -114,8 +116,9 @@ async function main() {
 	});
 
 	await test('runAsync should accept a cwd option', async () => {
-		const result = await runAsync('node -e "console.log(process.cwd())"', {silent: true, cwd: '/tmp'});
-		assert.strictEqual(result.stdout.trim(), '/tmp');
+		const cwd = os.tmpdir();
+		const result = await runAsync('node -e "console.log(process.cwd())"', {silent: true, cwd});
+		assert.strictEqual(result.stdout.trim(), cwd);
 	});
 
 	// runAllParallel tests
@@ -145,12 +148,13 @@ async function main() {
 	await test('runAllParallel should run faster than sequential for independent commands', async () => {
 		const start = Date.now();
 		await runAllParallel(
-			['node -e "setTimeout(()=>{},200)"', 'node -e "setTimeout(()=>{},200)"'],
+			['node -e "setTimeout(()=>{},1000)"', 'node -e "setTimeout(()=>{},1000)"'],
 			{silent: true},
 		);
 		const elapsed = Date.now() - start;
-		// Two 200ms commands in parallel should finish well under 400ms
-		assert.ok(elapsed < 380, `Expected elapsed < 380ms but got ${elapsed}ms`);
+		// Two one-second commands should overlap while allowing for process startup
+		// variance across Linux, Windows, and macOS runners.
+		assert.ok(elapsed < 1800, `Expected elapsed < 1800ms but got ${elapsed}ms`);
 	});
 
 	console.log(`\n${passed} passing, ${failed} failing`);

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const fs = require('fs');
 const os = require('os');
 const {run, runAll, runAsync, runAllParallel} = require('../src/run');
 
@@ -57,7 +58,7 @@ async function main() {
 	});
 
 	await test('should accept a cwd option', () => {
-		const cwd = os.tmpdir();
+		const cwd = fs.realpathSync(os.tmpdir());
 		const result = run('node -e "console.log(process.cwd())"', {silent: true, cwd});
 		assert.strictEqual(result.stdout.trim(), cwd);
 		assert.strictEqual(result.exitCode, 0);
@@ -116,7 +117,7 @@ async function main() {
 	});
 
 	await test('runAsync should accept a cwd option', async () => {
-		const cwd = os.tmpdir();
+		const cwd = fs.realpathSync(os.tmpdir());
 		const result = await runAsync('node -e "console.log(process.cwd())"', {silent: true, cwd});
 		assert.strictEqual(result.stdout.trim(), cwd);
 	});


### PR DESCRIPTION
## Summary

Makes AVA’s GitHub verification portable and starts it through the existing pull-request workflow.

## Changes

- runs CI on Ubuntu, Windows, and macOS;
- validates Node.js 20 and 22 on every operating system;
- adds manual `workflow_dispatch` support;
- runs the complete test suite plus `npm start` and a CLI smoke test;
- replaces hardcoded `/tmp` test paths with `os.tmpdir()`;
- gives the parallel timing test enough cross-platform process-startup tolerance.

## Safety

The workflow has read-only repository permissions. It does not deploy, use credentials, change external systems, or run privileged host actions.

## Local verification

- runner tests: 22 passing, 0 failing;
- color tests: 8 passing, 0 failing;
- state tests: 24 passing, 0 failing;
- CLI and library start smoke tests: passed;
- PowerShell parser checks require `pwsh`, which is unavailable in the isolated local environment;
- safe-local-node tests are blocked locally by restricted network-interface enumeration and are delegated to GitHub-hosted runners.

This pull request remains draft until the cross-platform GitHub Actions matrix is green.