### PR TITLE
Add AVA Security Safe defensive hardening playbook

### DIFF
--- a/security/AVA_SECURITY_SAFE_LEVEL_1000.ps1
+++ b/security/AVA_SECURITY_SAFE_LEVEL_1000.ps1
@@ -73,23 +73,28 @@ try {
 
         'Apply' {
             if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, 'Enable Windows Firewall and add narrowly scoped inbound block rules')) {
-                Set-NetFirewallProfile -Profile Domain,Private,Public \
-                    -Enabled True \
-                    -DefaultInboundAction Block \
-                    -DefaultOutboundAction Allow
+                $profileParams = @{
+                    Profile = @('Domain','Private','Public')
+                    Enabled = $true
+                    DefaultInboundAction = 'Block'
+                    DefaultOutboundAction = 'Allow'
+                }
+                Set-NetFirewallProfile @profileParams
 
                 $blockedTcpPorts = @(21,23,135,139,445,3389,5985,5986)
                 foreach ($port in $blockedTcpPorts) {
                     $ruleName = "AVA-SAFE-BLOCK-TCP-$port"
                     if (-not (Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue)) {
-                        New-NetFirewallRule \
-                            -DisplayName $ruleName \
-                            -Direction Inbound \
-                            -Action Block \
-                            -Protocol TCP \
-                            -LocalPort $port \
-                            -Profile Any \
-                            -Description 'AVA defensive local block rule. No outbound action.' | Out-Null
+                        $ruleParams = @{
+                            DisplayName = $ruleName
+                            Direction = 'Inbound'
+                            Action = 'Block'
+                            Protocol = 'TCP'
+                            LocalPort = $port
+                            Profile = 'Any'
+                            Description = 'AVA defensive local block rule. No outbound action.'
+                        }
+                        New-NetFirewallRule @ruleParams | Out-Null
                     }
                 }
 

--- a/security/AVA_SECURITY_SAFE_LEVEL_1000.ps1
+++ b/security/AVA_SECURITY_SAFE_LEVEL_1000.ps1
@@ -1,0 +1,155 @@
+#requires -Version 5.1
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [ValidateSet('Audit','Apply','Rollback')]
+    [string]$Mode = 'Audit',
+
+    [string]$CaseRoot = "$env:ProgramData\AVA\SecuritySafe",
+
+    [string]$FirewallBackupPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Test-IsAdministrator {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if (-not (Test-IsAdministrator)) {
+    throw 'PowerShell must be started as Administrator.'
+}
+
+$timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$caseDir = Join-Path $CaseRoot "AVA_CASE_$timestamp"
+New-Item -ItemType Directory -Path $caseDir -Force | Out-Null
+
+$transcriptPath = Join-Path $caseDir 'transcript.txt'
+Start-Transcript -Path $transcriptPath -Force | Out-Null
+
+try {
+    $result = [ordered]@{
+        TimestampUtc = (Get-Date).ToUniversalTime().ToString('o')
+        ComputerName = $env:COMPUTERNAME
+        UserName = "$env:USERDOMAIN\$env:USERNAME"
+        Mode = $Mode
+        SafetyBoundary = 'Defensive local hardening only. No counterattack, no remote scanning, no persistence, no endless loop.'
+        Actions = @()
+        Errors = @()
+    }
+
+    $firewallBackup = Join-Path $caseDir 'firewall_before.wfw'
+    & netsh.exe advfirewall export $firewallBackup | Out-Null
+    $result.Actions += "Firewall policy exported to $firewallBackup"
+
+    $snapshot = [ordered]@{}
+    $snapshot.FirewallProfiles = Get-NetFirewallProfile |
+        Select-Object Name, Enabled, DefaultInboundAction, DefaultOutboundAction
+    $snapshot.Defender = Get-MpComputerStatus |
+        Select-Object AntivirusEnabled, AntispywareEnabled, RealTimeProtectionEnabled,
+                      BehaviorMonitorEnabled, IoavProtectionEnabled, NISEnabled,
+                      AntivirusSignatureLastUpdated, QuickScanEndTime, FullScanEndTime
+    $snapshot.LocalAdministrators = Get-LocalGroupMember -Group 'Administrators' |
+        Select-Object Name, ObjectClass, PrincipalSource
+    $snapshot.EstablishedConnections = Get-NetTCPConnection -State Established -ErrorAction SilentlyContinue |
+        Select-Object LocalAddress, LocalPort, RemoteAddress, RemotePort, OwningProcess
+    $snapshot.NonMicrosoftScheduledTasks = Get-ScheduledTask |
+        Where-Object { $_.TaskPath -notlike '\Microsoft\*' } |
+        Select-Object TaskName, TaskPath, State, Author
+    $snapshot.Processes = Get-Process |
+        Sort-Object ProcessName |
+        Select-Object ProcessName, Id, Path, StartTime -ErrorAction SilentlyContinue
+
+    $snapshotPath = Join-Path $caseDir 'snapshot.json'
+    $snapshot | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $snapshotPath -Encoding UTF8
+    $result.Actions += "Read-only snapshot written to $snapshotPath"
+
+    switch ($Mode) {
+        'Audit' {
+            $result.Actions += 'Audit completed. No security settings changed.'
+        }
+
+        'Apply' {
+            if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, 'Enable Windows Firewall and add narrowly scoped inbound block rules')) {
+                Set-NetFirewallProfile -Profile Domain,Private,Public \
+                    -Enabled True \
+                    -DefaultInboundAction Block \
+                    -DefaultOutboundAction Allow
+
+                $blockedTcpPorts = @(21,23,135,139,445,3389,5985,5986)
+                foreach ($port in $blockedTcpPorts) {
+                    $ruleName = "AVA-SAFE-BLOCK-TCP-$port"
+                    if (-not (Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue)) {
+                        New-NetFirewallRule \
+                            -DisplayName $ruleName \
+                            -Direction Inbound \
+                            -Action Block \
+                            -Protocol TCP \
+                            -LocalPort $port \
+                            -Profile Any \
+                            -Description 'AVA defensive local block rule. No outbound action.' | Out-Null
+                    }
+                }
+
+                Update-MpSignature -ErrorAction Continue
+                $result.Actions += 'Firewall enabled for all profiles; inbound default set to block; outbound remains allowed.'
+                $result.Actions += "Inbound TCP blocks ensured for ports: $($blockedTcpPorts -join ', ')"
+                $result.Actions += 'Microsoft Defender signature update requested.'
+            }
+        }
+
+        'Rollback' {
+            if ([string]::IsNullOrWhiteSpace($FirewallBackupPath)) {
+                throw 'Rollback requires -FirewallBackupPath pointing to a previously exported .wfw file.'
+            }
+            if (-not (Test-Path -LiteralPath $FirewallBackupPath -PathType Leaf)) {
+                throw "Firewall backup not found: $FirewallBackupPath"
+            }
+            if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, "Restore firewall policy from $FirewallBackupPath")) {
+                & netsh.exe advfirewall import $FirewallBackupPath | Out-Null
+                $result.Actions += "Firewall policy restored from $FirewallBackupPath"
+            }
+        }
+    }
+
+    $reportJson = Join-Path $caseDir 'report.json'
+    $result | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $reportJson -Encoding UTF8
+
+    $encodedActions = ($result.Actions | ForEach-Object { '<li>' + [System.Net.WebUtility]::HtmlEncode($_) + '</li>' }) -join "`n"
+    $html = @"
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AVA Security Safe Report</title>
+<style>
+body{font-family:Segoe UI,Arial,sans-serif;background:#08111f;color:#e8f1ff;margin:2rem}
+main{max-width:1000px;margin:auto;background:#101d31;padding:2rem;border-radius:14px}
+h1{color:#56b4ff}.ok{color:#7ee787}.warn{color:#ffcc66}code{background:#06101d;padding:.15rem .35rem;border-radius:4px}
+</style>
+</head>
+<body><main>
+<h1>AVA Security Safe</h1>
+<p><strong>Mode:</strong> $Mode</p>
+<p class="ok"><strong>Boundary:</strong> Defensive local hardening only.</p>
+<p class="warn">No counterattack, remote scan, SYSTEM persistence, endless loop, credential action, or third-party targeting was performed.</p>
+<h2>Actions</h2><ul>$encodedActions</ul>
+<p>Evidence directory: <code>$caseDir</code></p>
+</main></body></html>
+"@
+    $reportHtml = Join-Path $caseDir 'report.html'
+    $html | Set-Content -LiteralPath $reportHtml -Encoding UTF8
+
+    Write-Host "AVA Security Safe completed: $caseDir" -ForegroundColor Green
+    Write-Host "JSON: $reportJson"
+    Write-Host "HTML: $reportHtml"
+}
+catch {
+    Write-Error $_
+    throw
+}
+finally {
+    Stop-Transcript | Out-Null
+}

--- a/security/AVA_SECURITY_SAFE_LEVEL_1000.ps1
+++ b/security/AVA_SECURITY_SAFE_LEVEL_1000.ps1
@@ -18,6 +18,11 @@ function Test-IsAdministrator {
     return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
+function Test-CommandAvailable {
+    param([Parameter(Mandatory)][string]$Name)
+    return [bool](Get-Command -Name $Name -ErrorAction SilentlyContinue)
+}
+
 if (-not (Test-IsAdministrator)) {
     throw 'PowerShell must be started as Administrator.'
 }
@@ -37,27 +42,73 @@ try {
         Mode = $Mode
         SafetyBoundary = 'Defensive local hardening only. No counterattack, no remote scanning, no persistence, no endless loop.'
         Actions = @()
-        Errors = @()
+        Warnings = @()
     }
 
     $firewallBackup = Join-Path $caseDir 'firewall_before.wfw'
     & netsh.exe advfirewall export $firewallBackup | Out-Null
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $firewallBackup)) {
+        throw 'Windows Firewall policy export failed. No changes were attempted.'
+    }
     $result.Actions += "Firewall policy exported to $firewallBackup"
 
     $snapshot = [ordered]@{}
-    $snapshot.FirewallProfiles = Get-NetFirewallProfile |
-        Select-Object Name, Enabled, DefaultInboundAction, DefaultOutboundAction
-    $snapshot.Defender = Get-MpComputerStatus |
-        Select-Object AntivirusEnabled, AntispywareEnabled, RealTimeProtectionEnabled,
-                      BehaviorMonitorEnabled, IoavProtectionEnabled, NISEnabled,
-                      AntivirusSignatureLastUpdated, QuickScanEndTime, FullScanEndTime
-    $snapshot.LocalAdministrators = Get-LocalGroupMember -Group 'Administrators' |
-        Select-Object Name, ObjectClass, PrincipalSource
-    $snapshot.EstablishedConnections = Get-NetTCPConnection -State Established -ErrorAction SilentlyContinue |
-        Select-Object LocalAddress, LocalPort, RemoteAddress, RemotePort, OwningProcess
-    $snapshot.NonMicrosoftScheduledTasks = Get-ScheduledTask |
-        Where-Object { $_.TaskPath -notlike '\Microsoft\*' } |
-        Select-Object TaskName, TaskPath, State, Author
+
+    if (Test-CommandAvailable 'Get-NetFirewallProfile') {
+        $snapshot.FirewallProfiles = Get-NetFirewallProfile |
+            Select-Object Name, Enabled, DefaultInboundAction, DefaultOutboundAction
+    }
+    else {
+        $snapshot.FirewallProfiles = @()
+        $result.Warnings += 'Get-NetFirewallProfile is unavailable.'
+    }
+
+    if (Test-CommandAvailable 'Get-MpComputerStatus') {
+        $snapshot.Defender = Get-MpComputerStatus |
+            Select-Object AntivirusEnabled, AntispywareEnabled, RealTimeProtectionEnabled,
+                          BehaviorMonitorEnabled, IoavProtectionEnabled, NISEnabled,
+                          AntivirusSignatureLastUpdated, QuickScanEndTime, FullScanEndTime
+    }
+    else {
+        $snapshot.Defender = $null
+        $result.Warnings += 'Microsoft Defender status command is unavailable.'
+    }
+
+    if (Test-CommandAvailable 'Get-LocalGroup') {
+        $administratorsGroup = Get-LocalGroup -SID 'S-1-5-32-544' -ErrorAction SilentlyContinue
+        if ($null -ne $administratorsGroup) {
+            $snapshot.LocalAdministrators = Get-LocalGroupMember -Group $administratorsGroup.Name |
+                Select-Object Name, ObjectClass, PrincipalSource
+        }
+        else {
+            $snapshot.LocalAdministrators = @()
+            $result.Warnings += 'Local Administrators group could not be resolved by SID.'
+        }
+    }
+    else {
+        $snapshot.LocalAdministrators = @()
+        $result.Warnings += 'LocalAccounts module is unavailable.'
+    }
+
+    if (Test-CommandAvailable 'Get-NetTCPConnection') {
+        $snapshot.EstablishedConnections = Get-NetTCPConnection -State Established -ErrorAction SilentlyContinue |
+            Select-Object LocalAddress, LocalPort, RemoteAddress, RemotePort, OwningProcess
+    }
+    else {
+        $snapshot.EstablishedConnections = @()
+        $result.Warnings += 'Get-NetTCPConnection is unavailable.'
+    }
+
+    if (Test-CommandAvailable 'Get-ScheduledTask') {
+        $snapshot.NonMicrosoftScheduledTasks = Get-ScheduledTask |
+            Where-Object { $_.TaskPath -notlike '\Microsoft\*' } |
+            Select-Object TaskName, TaskPath, State, Author
+    }
+    else {
+        $snapshot.NonMicrosoftScheduledTasks = @()
+        $result.Warnings += 'ScheduledTasks module is unavailable.'
+    }
+
     $snapshot.Processes = Get-Process |
         Sort-Object ProcessName |
         Select-Object ProcessName, Id, Path, StartTime -ErrorAction SilentlyContinue
@@ -72,6 +123,11 @@ try {
         }
 
         'Apply' {
+            if (-not (Test-CommandAvailable 'Set-NetFirewallProfile') -or
+                -not (Test-CommandAvailable 'New-NetFirewallRule')) {
+                throw 'Required Windows Firewall PowerShell commands are unavailable. No changes were attempted.'
+            }
+
             if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, 'Enable Windows Firewall and add narrowly scoped inbound block rules')) {
                 $profileParams = @{
                     Profile = @('Domain','Private','Public')
@@ -98,10 +154,16 @@ try {
                     }
                 }
 
-                Update-MpSignature -ErrorAction Continue
+                if (Test-CommandAvailable 'Update-MpSignature') {
+                    Update-MpSignature -ErrorAction Continue
+                    $result.Actions += 'Microsoft Defender signature update requested.'
+                }
+                else {
+                    $result.Warnings += 'Microsoft Defender signature command is unavailable.'
+                }
+
                 $result.Actions += 'Firewall enabled for all profiles; inbound default set to block; outbound remains allowed.'
                 $result.Actions += "Inbound TCP blocks ensured for ports: $($blockedTcpPorts -join ', ')"
-                $result.Actions += 'Microsoft Defender signature update requested.'
             }
         }
 
@@ -114,6 +176,9 @@ try {
             }
             if ($PSCmdlet.ShouldProcess($env:COMPUTERNAME, "Restore firewall policy from $FirewallBackupPath")) {
                 & netsh.exe advfirewall import $FirewallBackupPath | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    throw 'Windows Firewall policy import failed.'
+                }
                 $result.Actions += "Firewall policy restored from $FirewallBackupPath"
             }
         }
@@ -123,6 +188,7 @@ try {
     $result | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $reportJson -Encoding UTF8
 
     $encodedActions = ($result.Actions | ForEach-Object { '<li>' + [System.Net.WebUtility]::HtmlEncode($_) + '</li>' }) -join "`n"
+    $encodedWarnings = ($result.Warnings | ForEach-Object { '<li>' + [System.Net.WebUtility]::HtmlEncode($_) + '</li>' }) -join "`n"
     $html = @"
 <!doctype html>
 <html lang="en">
@@ -141,6 +207,7 @@ h1{color:#56b4ff}.ok{color:#7ee787}.warn{color:#ffcc66}code{background:#06101d;p
 <p class="ok"><strong>Boundary:</strong> Defensive local hardening only.</p>
 <p class="warn">No counterattack, remote scan, SYSTEM persistence, endless loop, credential action, or third-party targeting was performed.</p>
 <h2>Actions</h2><ul>$encodedActions</ul>
+<h2>Warnings</h2><ul>$encodedWarnings</ul>
 <p>Evidence directory: <code>$caseDir</code></p>
 </main></body></html>
 "@
@@ -156,5 +223,5 @@ catch {
     throw
 }
 finally {
-    Stop-Transcript | Out-Null
+    Stop-Transcript -ErrorAction SilentlyContinue | Out-Null
 }

--- a/security/README_SECURITY_SAFE_LEVEL_1000.md
+++ b/security/README_SECURITY_SAFE_LEVEL_1000.md
@@ -1,0 +1,68 @@
+# AVA SECURITY SAFE — Defensive Mode
+
+This package is intentionally limited to **local defensive hardening and evidence collection**.
+
+## Safety boundary
+
+Allowed:
+
+- Export the current Windows Firewall policy before changes.
+- Record a local snapshot of firewall, Defender, administrators, scheduled tasks, processes, and established connections.
+- Enable all Windows Firewall profiles.
+- Set the default inbound action to `Block` while leaving outbound traffic allowed.
+- Add named inbound block rules for TCP ports `21, 23, 135, 139, 445, 3389, 5985, 5986`.
+- Request a Microsoft Defender signature update.
+- Produce JSON, HTML, and transcript evidence.
+- Restore a previously exported firewall policy.
+
+Not included:
+
+- Counterattacks or retaliation.
+- Scanning, probing, exploiting, flooding, redirecting, or disrupting remote systems.
+- SYSTEM scheduled tasks or other persistence.
+- Endless loops.
+- Credential collection or account manipulation.
+- Automatic deletion of evidence.
+
+## Recommended sequence
+
+Open **Windows PowerShell as Administrator** from the repository folder.
+
+### 1. Preview the changes
+
+```powershell
+.\security\AVA_SECURITY_SAFE_LEVEL_1000.ps1 -Mode Apply -WhatIf
+```
+
+### 2. Collect a read-only snapshot
+
+```powershell
+.\security\AVA_SECURITY_SAFE_LEVEL_1000.ps1 -Mode Audit
+```
+
+### 3. Apply the defensive firewall policy
+
+```powershell
+.\security\AVA_SECURITY_SAFE_LEVEL_1000.ps1 -Mode Apply -Confirm
+```
+
+The script stores its case folder under:
+
+```text
+C:\ProgramData\AVA\SecuritySafe\AVA_CASE_YYYYMMDD_HHMMSS
+```
+
+Each case contains the firewall backup, transcript, snapshot, JSON report, and HTML report.
+
+### 4. Roll back when required
+
+```powershell
+.\security\AVA_SECURITY_SAFE_LEVEL_1000.ps1 `
+  -Mode Rollback `
+  -FirewallBackupPath 'C:\ProgramData\AVA\SecuritySafe\AVA_CASE_...\firewall_before.wfw' `
+  -Confirm
+```
+
+## Operational note
+
+Blocking RDP, SMB, WinRM, FTP, Telnet, and related inbound ports can interrupt services that are deliberately in use. Preview with `-WhatIf`, keep the exported `.wfw` backup, and apply only on systems you own or administer.


### PR DESCRIPTION
## Summary

Adds a defensive-only Windows security playbook and documentation.

### Included
- Read-only evidence snapshot
- Windows Firewall export before changes
- Optional inbound firewall hardening
- Defender signature update request
- JSON, HTML, and transcript reporting
- Firewall rollback support

### Explicit safety boundary
- No counterattack or retaliation
- No remote scanning or exploitation
- No SYSTEM persistence
- No endless loop
- No credential or third-party targeting

The script defaults to `Audit` mode and supports `-WhatIf` and `-Confirm` for controlled application.